### PR TITLE
Refactor vet argument

### DIFF
--- a/scripts/build/static-analysis.sh
+++ b/scripts/build/static-analysis.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 echo "Running go vet..."
-go vet $(go list ./... | grep -v ./vendor)
+go vet $(glide novendor)


### PR DESCRIPTION
Given that we've already installed glide, we can refactor using glide's novendor command:

Replace this `$(go list ./... | grep -v ./vendor)`  with this `$(glide novendor)`